### PR TITLE
update geometry.ex to force recompilation on upgrade

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -1,7 +1,7 @@
 if Code.ensure_loaded?(Ecto.Type) do
   defmodule Geo.PostGIS.Geometry do
     @moduledoc """
-    Implements the Ecto.Type behaviour for all geometry types
+    Implements the Ecto.Type behaviour for all geometry types.
     """
 
     alias Geo.{


### PR DESCRIPTION
This will fix the upgrade weirdness when switching between branches on 3.4.3 and 3.4.4.  Right now since all we did was add the optional dependency, it apparently isn't enough to encourage Elixir 1.15 to recompile this module -- however, if we actually make a (very minor) change on the upgrade, it will recompile every time.